### PR TITLE
Add extra_data params to social_auth configuration

### DIFF
--- a/backend/settings/base.py
+++ b/backend/settings/base.py
@@ -176,6 +176,10 @@ AUTHENTICATION_BACKENDS = (
 SOCIAL_AUTH_GITHUB_KEY = os.getenv('SOCIAL_AUTH_GITHUB_KEY')
 SOCIAL_AUTH_GITHUB_SECRET = os.getenv('SOCIAL_AUTH_GITHUB_SECRET')
 SOCIAL_AUTH_GITHUB_SCOPE = ['user']
+SOCIAL_AUTH_GITHUB_EXTRA_DATA = [
+    ('name', 'name'),
+    ('avatar_url', 'avatar_url')
+]
 
 # DJANGO OAUTH TOOLKIT ID and SECRET used for Github authentication
 # https://github.com/RealmTeam/django-rest-framework-social-oauth2


### PR DESCRIPTION
Partial fix for #88 

P.S. I'm yet to autopopulate the custom user field with the avatar url value, it needs to have a one-to-one relationship with the default django user model and our custom user model doesn't have that relationship. Need to know how to proceed with this.