### PR TITLE
Readd heroku prod environment name

### DIFF
--- a/backend/settings/__init__.py
+++ b/backend/settings/__init__.py
@@ -6,7 +6,7 @@ from dotenv import load_dotenv
 load_dotenv()
 
 # Ensure development settings are not used in testing and production:
-if os.getenv("PRODUCTION"):
+if os.getenv("ENVIRONMENT") == "PRODUCTION":
     from .production import *
 elif os.getenv("GITHUB_WORKFLOW"):
     from .test import *


### PR DESCRIPTION
Edited init file because the dict key for 'production' value on Heroku is named 'environment' and that name doesn't exist for github_workflow. I was unable to make migrations on Heroku because Heroku probably isn't importing the production settings file