### PR TITLE
Add check for pre-existing user data

### DIFF
--- a/app/views/github_oauth.py
+++ b/app/views/github_oauth.py
@@ -25,14 +25,17 @@ def github_authenticate(request):
 
     github_user = retrieve_github_user_info(token=github_token)
 
-    user, created = User.objects.get_or_create(
-        username=github_user.get("name"),
-        avatar=github_user.get("avatar_url"),
-        email=github_user.get("email"),
-        timezone=github_user.get("location"),
-    )
+    try:
+        user = User.objects.get(email=github_user.get("email"))
+    except User.DoesNotExist:
+        user, created = User.objects.get_or_create(
+            username=github_user.get("name"),
+            avatar=github_user.get("avatar_url"),
+            email=github_user.get("email"),
+            timezone=github_user.get("location"),
+        )
 
-    if user is None and created is False:
+    if user is None:
         raise exceptions.AuthenticationFailed("user not created")
 
     res = get_refresh_access_token(user)

--- a/app/views/gitlab_oauth.py
+++ b/app/views/gitlab_oauth.py
@@ -28,13 +28,16 @@ def gitlab_authenticate(request):
 
     gitlab_user = retrieve_gitlab_user_info(access_token=gitlab_token)
 
-    user, created = User.objects.get_or_create(
-        username=gitlab_user.get("name"),
-        avatar=gitlab_user.get("avatar_url"),
-        email=gitlab_user.get("email"),
-    )
+    try:
+        user = User.objects.get(email=gitlab_user.get("email"))
+    except User.DoesNotExist:
+        user, created = User.objects.get_or_create(
+            username=gitlab_user.get("name"),
+            avatar=gitlab_user.get("avatar_url"),
+            email=gitlab_user.get("email"),
+        )
 
-    if user is None and created is False:
+    if user is None:
         raise exceptions.AuthenticationFailed("user not created")
 
     res = get_refresh_access_token(user)


### PR DESCRIPTION
Fixes integrity error caused by trying to login with either github/gitlab when the user already exists in the database.